### PR TITLE
아이디 찾기 및 비밀번호 재설정 기능 완료

### DIFF
--- a/src/config/response.status.js
+++ b/src/config/response.status.js
@@ -32,4 +32,18 @@ export const status = {
   // refreshToken err
   REFRESH_TOKEN_NOT_PROVIDED: { status: StatusCodes.UNAUTHORIZED, isSuccess: false, code: "REFRESHTOKEN001", message: "refresh 토큰이 제공되지 않았습니다." },
   REFRESH_TOKEN_INVALID: { status: StatusCodes.PAYMENT_REQUIRED, isSuccess: false, code: "REFRESHTOKEN002", message: "유효하지 않은 refresh 토큰입니다." },
+
+  // find-id err
+  FIND_ID_EMPTY_DATA: { status: StatusCodes.UNAUTHORIZED, isSuccess: false, code: "FINDID001", message: "데이터가 비어있습니다." },
+  FIND_ID_USER_NOT_FOUND: { status: StatusCodes.PAYMENT_REQUIRED, isSuccess: false, code: "FINDID002", message: "존재하지 않는 사용자입니다." },
+
+  // auth-reset-password err
+  AUTH_RESET_PASSWORD_EMPTY_DATA: { status: StatusCodes.UNAUTHORIZED, isSuccess: false, code: "AUTHRESETPASSWORD001", message: "데이터가 비어있습니다." },
+  AUTH_RESET_PASSWORD_USER_NOT_FOUND: { status: StatusCodes.PAYMENT_REQUIRED, isSuccess: false, code: "AUTHRESETPASSWORD002", message: "존재하지 않는 사용자입니다." },
+
+  // set-reset-password err
+  SET_RESET_PASSWORD_EMPTY_TOKEN: { status: StatusCodes.UNAUTHORIZED, isSuccess: false, code: "SETRESETPASSWORD001", message: "비밀번호 변경 권한 토큰이 존재하지 않습니다." },
+  SET_RESET_PASSWORD_EMPTY_NEW_PASSWORD: { status: StatusCodes.PAYMENT_REQUIRED, isSuccess: false, code: "SETRESETPASSWORD002", message: "변경할 비밀번호 데이터가 비어있습니다." },
+  SET_RESET_PASSWORD_CHANGE_PASSWORD_ERROR: { status: StatusCodes.FORBIDDEN, isSuccess: false, code: "SETRESETPASSWORD003", message: "비밀번호 변경에 실패했습니다." },
+  SET_RESET_PASSWORD_VERIFY_TOKEN_ERROR: { status: StatusCodes.NOT_ACCEPTABLE, isSuccess: false, code: "SETRESETPASSWORD004", message: "비밀번호 변경 권한 토큰이 유효하지 않습니다." },
 };

--- a/src/domains/auth/auth.controller.js
+++ b/src/domains/auth/auth.controller.js
@@ -1,0 +1,90 @@
+import { response } from "../../config/response.js";
+import { status } from "../../config/response.status.js";
+import { AuthResetPasswordCookie, AuthResetPasswordService, FindUserIdService, SetResetPasswordService, SetResetPasswordVerifyToken } from "./auth.service.js";
+export async function FindUserId(req, res) {
+    try {
+        const { name, email} = req.body;
+
+        if (!name || !email) {
+            return res.send(response(status.FIND_ID_EMPTY_DATA));
+        }
+
+        const result = await FindUserIdService(name,email);
+
+        if (result.code == 401) {
+            return res.send(response(status.FIND_ID_USER_NOT_FOUND));
+        }
+        if(result.code == 500){
+            return res.send(response(status.INTERNAL_SERVER_ERROR));
+        }
+
+        return res.send(response(status.SUCCESS,result));
+    } catch (err) {
+        console.error(err);
+        return res.send(response(status.INTERNAL_SERVER_ERROR));
+    }
+}
+
+export async function AuthResetPassword(req, res) {
+    try {
+        const { name, email, user_id } = req.body;
+
+        if (!name || !email || !user_id) {
+            return res.send(response(status.AUTH_RESET_PASSWORD_EMPTY_DATA));
+        }
+
+        const result = await AuthResetPasswordService(name, email, user_id);
+
+        if (result.code == 401) {
+            return res.send(response(status.AUTH_RESET_PASSWORD_USER_NOT_FOUND));
+        }
+        if (result.code == 500) {
+            return res.send(response(status.INTERNAL_SERVER_ERROR));
+        }
+
+        const newPasswordKey = await AuthResetPasswordCookie(result.uuid);
+
+        res.cookie('newPasswordKey', newPasswordKey, { httpOnly: true, secure: false });
+
+        return res.send(response(status.SUCCESS));
+    } catch (err) {
+        console.error(err);
+        return res.send(response(status.INTERNAL_SERVER_ERROR));
+    }
+}
+
+export async function SetResetPassword(req, res) {
+    try {
+        const newPasswordKey = req.cookies.newPasswordKey;
+        if(!newPasswordKey){
+            return res.send(response(status.SET_RESET_PASSWORD_EMPTY_TOKEN));
+        }
+
+        const decoded = await SetResetPasswordVerifyToken(newPasswordKey);
+
+        if(!decoded){
+            return res.send(response(status.SET_RESET_PASSWORD_VERIFY_TOKEN_ERROR));
+        }
+
+        const uuid = decoded.uuid;
+        const { newPassword } = req.body;
+        if (!newPassword ) {
+            return res.send(response(status.SET_RESET_PASSWORD_EMPTY_NEW_PASSWORD));
+        }
+
+        const result = await SetResetPasswordService(uuid,newPassword);
+        if(result.code == 403){
+            return res.send(response(status.SET_RESET_PASSWORD_CHANGE_PASSWORD_ERROR));
+        }
+        if(result.code == 500){
+            return res.send(response(status.INTERNAL_SERVER_ERROR));
+        }
+
+        res.clearCookie('newPasswordKey');
+
+        return res.send(response(status.SUCCESS));
+    } catch (err) {
+        console.error(err);
+        return res.send(response(status.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/domains/auth/auth.dao.js
+++ b/src/domains/auth/auth.dao.js
@@ -1,0 +1,52 @@
+import { Op } from "sequelize";
+import db from "../../db/index.js";
+export async function FindUserRepository(name,email){
+    try{
+        const isExistUser = await db.Member.findOne({
+            where: {
+                [Op.and]: [
+                  { name },
+                  { email }
+                ]
+            }
+        });
+        return isExistUser;
+    }catch(err){
+        console.error(err);
+        return false;
+    }
+}
+
+export async function AuthResetPasswordRepository(name,email,user_id){
+    try{
+        const isExistUser = await db.Member.findOne({
+            where: {
+                [Op.and]: [
+                  { name },
+                  { email },
+                  { user_id },
+                ]
+            }
+        });
+        return isExistUser;
+    }catch(err){
+        console.error(err);
+        return false;
+    }
+}
+
+export async function SetResetPasswordRepository(uuid,hashedPassword){
+    try{
+        const result = await db.Member.update({
+            password:hashedPassword,
+        }, {
+            where: {
+                uuid,
+            }
+        });
+        return result;
+    }catch(err){
+        console.error(err);
+        return false;
+    }
+}

--- a/src/domains/auth/auth.service.js
+++ b/src/domains/auth/auth.service.js
@@ -1,0 +1,71 @@
+import { AuthResetPasswordRepository, FindUserRepository, SetResetPasswordRepository } from "./auth.dao.js";
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+
+export async function FindUserIdService(name,email){
+    try{
+        const isExistUser = await FindUserRepository(name,email);
+        if(!isExistUser){
+            return { success: false, code:401 ,message: "사용자 존재하지 않음" };
+        }
+        const userData = {
+            email:isExistUser.email,
+            name:isExistUser.name,
+            user_id:isExistUser.user_id,
+        }
+        return userData;
+    }catch(err){
+        console.error(err);
+        return { success: false, code:500 ,message: "서버 오류" };
+    }
+}
+
+export async function AuthResetPasswordService(name, email, user_id){
+    try{
+        const isExistUser = await AuthResetPasswordRepository(name,email,user_id);
+        if(!isExistUser){
+            return { success: false, code:401 ,message: "사용자 존재하지 않음" };
+        }
+        return isExistUser;
+    }catch(err){
+        console.error(err);
+        return { success: false, code:500 ,message: "서버 오류" };
+    }
+}
+export async function AuthResetPasswordCookie(uuid){
+    try{
+        const newPasswordKey = jwt.sign({
+            uuid,
+        }, process.env.JWT_SECRET_KEY, { 
+            expiresIn: '5m' 
+        });
+        return newPasswordKey;
+    }catch(err){
+        console.error(err);
+        return { success: false, code:500 ,message: "서버 오류" }; 
+    }
+}
+
+export async function SetResetPasswordVerifyToken(token){
+    try{
+        const result = jwt.verify(token,process.env.JWT_SECRET_KEY);
+        return result;
+    }catch(err){
+        console.error(err);
+        return { success: false, code:500 ,message: "서버 오류" }; 
+    }
+}
+
+export async function SetResetPasswordService(uuid,newPassword){
+    try{
+        const hashedPassword = await bcrypt.hash(newPassword, 10);
+        const SetResetPassword = await SetResetPasswordRepository(uuid,hashedPassword);
+        if(!SetResetPassword){
+            return { success: false, code:403 ,message: "비밀번호 변경 실패" };
+        }
+        return SetResetPassword
+    }catch(err){
+        console.error(err);
+        return { success: false, code:500 ,message: "서버 오류" }; 
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { loginRouter } from './routes/login.js';
 import { searchRouter } from './routes/search.js';
 import { refreshTokenRouter } from './routes/refreshToken.js';
 import sizeUploadRoutes from './routes/uploadsize.routes.js';
+import { AuthRouter } from './routes/auth.js';
 
 dotenv.config();
 
@@ -42,7 +43,7 @@ app.use("/FITple/login",loginRouter);
 app.use('/FITple/search', searchRouter);
 app.use('/FITple/uploadsize', sizeUploadRoutes);
 app.use("/FITple/refreshToken",refreshTokenRouter);
-
+app.use("/FITple/auth",AuthRouter)
 
 // error handling
 app.use((req, res, next) => {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { AuthResetPassword, FindUserId, SetResetPassword } from '../domains/auth/auth.controller.js';
+
+export const AuthRouter = express.Router();
+
+AuthRouter.post('/find-id',FindUserId);
+AuthRouter.post('/reset-password',AuthResetPassword);
+AuthRouter.patch('/reset-password',SetResetPassword);

--- a/src/swagger/findId.swagger.yaml
+++ b/src/swagger/findId.swagger.yaml
@@ -1,0 +1,113 @@
+paths:
+  /FITple/auth/find-id:
+    post:
+      tags:
+        - Find-id
+      summary: 아이디 찾기
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: 유저 이메일
+                  example: swaggerTest@naver.com
+                name:
+                  type: string
+                  description: 유저 이름
+                  example: test
+              required:
+                - email
+                - name
+      responses:
+        '200':
+          description: 아이디 찾기 성공!
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: number
+                example: 200
+              message:
+                type: string
+                example: "success!"
+              result:
+                type: object
+                properties:
+                  user:
+                    type: object
+                    properties:
+                      user_id:
+                        type: string
+                        description: 유저 아이디
+                        example: swaggerTest
+                      email:
+                        type: string
+                        description: 유저 이메일
+                        example: swaggerTest@naver.com
+                      name:
+                        type: string
+                        description: 유저 이름
+                        example: test
+        '400':
+          description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: string
+                example: COMMON001
+              message:
+                type: string
+                example: 잘못된 요청입니다
+        '401':
+          description: 비어있는 데이터
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: string
+                example: FINDID002
+              message:
+                type: string
+                example: 데이터가 비어있습니다.
+        '402':
+          description: 존재하지 않는 사용자
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: string
+                example: FINDID002
+              message:
+                type: string
+                example: 존재하지 않는 사용자입니다.
+        '500':
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              isSuccess:
+                type: boolean
+                example: false
+              code:
+                type: string
+                example: COMMON000
+              message:
+                type: string
+                example: 서버 에러, 관리자에게 문의 바랍니다.

--- a/src/swagger/resetPassword.swagger.yaml
+++ b/src/swagger/resetPassword.swagger.yaml
@@ -1,0 +1,241 @@
+paths:
+  /FITple/auth/reset-password:
+    post:
+      tags:
+        - Reset-Password
+      summary: 비밀번호 변경 권한 확인
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: string
+                  description: 유저 아이디
+                  example: swaggerTest
+                email:
+                  type: string
+                  description: 유저 이메일
+                  example: swaggerTest@naver.com
+                name:
+                  type: string
+                  description: 유저 이름
+                  example: test
+              required:
+                - user_id
+                - email
+                - name
+      responses:
+        '200':
+          description: 비밀번호 변경 권한 확인 성공!
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: number
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+        '400':
+          description: 잘못된 요청
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: COMMON001
+                  message:
+                    type: string
+                    example: 잘못된 요청입니다
+        '401':
+          description: 비어있는 데이터
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: AUTHRESETPASSWORD001
+                  message:
+                    type: string
+                    example: 데이터가 비어있습니다.
+        '402':
+          description: 존재하지 않는 사용자
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: AUTHRESETPASSWORD002
+                  message:
+                    type: string
+                    example: 존재하지 않는 사용자입니다.
+        '500':
+          description: 서버 에러
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: COMMON000
+                  message:
+                    type: string
+                    example: 서버 에러, 관리자에게 문의 바랍니다.
+
+    patch:
+      tags:
+        - Reset-Password
+      summary: 비밀번호 변경
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                newPassword:
+                  type: string
+                  description: 변경할 비밀번호
+                  example: 7654321
+              required:
+                - newPassword
+      responses:
+        '200':
+          description: 비밀번호 변경 성공!
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: true
+                  code:
+                    type: number
+                    example: 200
+                  message:
+                    type: string
+                    example: "success!"
+        '400':
+          description: 잘못된 요청
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: COMMON001
+                  message:
+                    type: string
+                    example: 잘못된 요청입니다
+        '401':
+          description: 비밀번호 변경 권한 토큰 없음
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: SETRESETPASSWORD001
+                  message:
+                    type: string
+                    example: 비밀번호 변경 권한 토큰이 존재하지 않습니다.
+        '402':
+          description: 변경할 비밀번호 데이터 없음
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: SETRESETPASSWORD002
+                  message:
+                    type: string
+                    example: 변경할 비밀번호 데이터가 존재하지 않습니다.
+        '403':
+          description: 비밀번호 변경에 실패
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: SETRESETPASSWORD003
+                  message:
+                    type: string
+                    example: 비밀번호 변경에 실패했습니다.
+        '406':
+          description: 유효하지 않은 비밀번호 변경 권한 토큰
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: SETRESETPASSWORD004
+                  message:
+                    type: string
+                    example: 비밀번호 변경 권한 토큰이 유효하지 않습니다.
+        '500':
+          description: 서버 에러
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isSuccess:
+                    type: boolean
+                    example: false
+                  code:
+                    type: string
+                    example: COMMON000
+                  message:
+                    type: string
+                    example: 서버 에러, 관리자에게 문의 바랍니다.


### PR DESCRIPTION
### 🎋 작업중인 브랜치

- feat/#26_backend_findId_resetPassword

### ⚡️ 작업동기

- 아이디 찾기 기능 
- 비밀번호 재설정 권한 확인 기능 
- 비밀번호 재설정 기능

### 🔑 주요 변경사항

- 비밀번호 재설정 권한 ( 토큰 쿠키 )을 발급 받아야 비밀번호 재설정을 할 수 있습니다.
- 비밀번호 재설정 기능 Fimga를 보게 되면 사용자 아이디, 이메일, 이름을 입력하고 바로 비밀번호 재설정을 하러 가는 것이 아닌, 사용자에게 다시 입력한 사용자 아이디, 이메일, 이름을 보여준 뒤 비밀번호 재설정 기능을 실행 할 수 있게 만들었는데, 일단 사용자에게 사용자 아이디, 이메일, 이름을 입력받고 권한을 준 뒤 바로 비밀번호 재설정 기능이 실행되게끔 만들어 놨습니다. PM님께 여쭤봤는데 답장이 아직 안 와서, 오는대로 수정하거나, 그대로 두거나 하겠습니다! 
- 아이디 찾기와 비밀번호를 찾는 로직을 실행시킬 때, 사용자 이름 데이터가 필요합니다. 근데 사용자 이름 데이터는 내 프로필 설정을 한 뒤 생기는 데이터라 일단 임시로 DB Member 테이블 조작하셔서 테스트 해주시면 감사하겠습니다. 

### 💡 관련 이슈

- 
<img width="1093" alt="스크린샷 2024-08-13 오후 5 45 47" src="https://github.com/user-attachments/assets/12f08c4b-0f5d-41b0-974d-4e97af3e8f4f">
<img width="1083" alt="스크린샷 2024-08-13 오후 5 50 52" src="https://github.com/user-attachments/assets/93a54db3-1996-46b5-9b90-f467e0e6e9ea">
<img width="1079" alt="스크린샷 2024-08-13 오후 5 51 02" src="https://github.com/user-attachments/assets/e5ff5e38-7eca-4119-91ec-cf95ee253a90">
<img width="1085" alt="스크린샷 2024-08-13 오후 5 52 53" src="https://github.com/user-attachments/assets/680ef115-56a0-4e76-a69c-d7e6c360628b">
<img width="1071" alt="스크린샷 2024-08-13 오후 5 52 59" src="https://github.com/user-attachments/assets/c9f21a3d-2f5e-454f-8304-e768342016a8">
<img width="1080" alt="스크린샷 2024-08-13 오후 5 53 25" src="https://github.com/user-attachments/assets/45d56380-fbf3-46dd-af07-b339fdd824c6">


