### PR TITLE
CI/CD 파이프라인 수정

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['18', '16', '14']  # 노드 버전 지정! 여러 개도 가능! ['18.x', '14.x'] 요렇게
+        node-version: ['18', '16']  # 노드 버전 지정! 여러 개도 가능! ['18.x', '14.x'] 요렇게
         
     steps:
       # build 할 코드를 가져옴 (코드 checkout - github에서 제공해주는 checkout@v3 사용)


### PR DESCRIPTION
### 🎋 작업중인 브랜치

- fix/#39_backend_cicd-6

### ⚡️ 작업동기

- Actions Set up Node.js 14 에러 해결

### 🔑 주요 변경사항

- dev_deploy 파일 노드 버전 14 삭제

### 💡 관련 이슈

- #39 
- 현재 pnpm 버전 사용하려면 Node.js v16.14 이상 이어야 합니다
