### PR TITLE
CI/CD 파이프라인 수정

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['18', '16']  # 노드 버전 지정! 여러 개도 가능! ['18.x', '14.x'] 요렇게
+        node-version: ['18']  # 노드 버전 지정
         
     steps:
       # build 할 코드를 가져옴 (코드 checkout - github에서 제공해주는 checkout@v3 사용)


### PR DESCRIPTION
### 🎋 작업중인 브랜치

- fix/#41_backend_cicd-7

### ⚡️ 작업동기

- Actions Beanstalk 에러 해결

### 🔑 주요 변경사항

- dev_deploy 파일 노드 버전 16 삭제하고 18만 사용

### 💡 관련 이슈

- #41 
- 노드 버전 두 개 사용 시 Actions에서 나중에 빌드되는 버전에서 Beanstalk 에러 발생
