### PR TITLE
스타일 추천 로직 구현

### DIFF
--- a/src/domains/recommend/recommend.controller.js
+++ b/src/domains/recommend/recommend.controller.js
@@ -1,0 +1,9 @@
+import { response } from "../../config/response.js";
+import { status } from "../../config/response.status.js";
+import { getStyle } from "./recommend.provider.js";
+
+export const style = async (req, res, next) => {
+    console.log("비슷한 스타일의 유저를 추천합니다");
+    const userId = res.locals.uuid;
+    res.send(response(status.SUCCESS, await getStyle(userId)));
+}

--- a/src/domains/recommend/recommend.controller.js
+++ b/src/domains/recommend/recommend.controller.js
@@ -1,9 +1,15 @@
 import { response } from "../../config/response.js";
 import { status } from "../../config/response.status.js";
-import { getStyle } from "./recommend.provider.js";
+import { getStyle, getStyleAll } from "./recommend.provider.js";
 
 export const style = async (req, res, next) => {
     console.log("비슷한 스타일의 유저를 추천합니다");
     const userId = res.locals.uuid;
     res.send(response(status.SUCCESS, await getStyle(userId)));
+}
+
+export const styleAll = async (req, res, next) => {
+    console.log("비슷한 스타일의 유저를 모두 추천합니다");
+    const userId = res.locals.uuid;
+    res.send(response(status.SUCCESS, await getStyleAll(userId)));
 }

--- a/src/domains/recommend/recommend.dao.js
+++ b/src/domains/recommend/recommend.dao.js
@@ -1,7 +1,7 @@
 import { pool } from "../../config/db.config.js";
 import { BaseError } from "../../config/error.js";
 import { status } from "../../config/response.status.js";
-import { getUser, getFitToUserId, getStyleToUserId, findUserToStyle1, findUserToStyle2 } from "./recommend.sql.js";
+import { getUser, getFitToUserId, getStyleToUserId, findUserToStyle1, findUserToStyle2, findUserAllToStyle1, findUserAllToStyle2 } from "./recommend.sql.js";
 
 export const getStyleDAO = async (userId) => {
     try {
@@ -14,6 +14,42 @@ export const getStyleDAO = async (userId) => {
             recommend = await pool.query(findUserToStyle1, [userId, style[0][0].style_name]);
         }else if(style[0].length = 2){
             recommend = await pool.query(findUserToStyle2, [userId, style[0][1].style_name, style[0].style_name]);
+        }else{
+            throw new BaseError(status.MYPROFILE_PREFER_STYLE_LENGHT_ERROR);
+        }
+
+        if(recommend[0].length == 0){
+            conn.release();
+            return -1;
+        }else{
+            for (let i = 0; i < recommend[0].length; i++) {
+                const user = await pool.query(getUser, recommend[0][i].uuid);
+                const fit = await pool.query(getFitToUserId, recommend[0][i].uuid);
+                const style = await pool.query(getStyleToUserId, recommend[0][i].uuid);
+                result.push({user, fit, style});
+            }
+        }
+        conn.release();
+        return result;
+    } catch (err) {
+        if (err.data.code === status.MYPROFILE_PREFER_STYLE_LENGHT_ERROR.code) {
+            throw err;
+        }
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
+}
+
+export const getStyleAllDAO = async (userId) => {
+    try {
+        const conn = await pool.getConnection();
+        const result = [];
+        const style = await pool.query(getStyleToUserId, userId);
+        let recommend;
+
+        if(style[0].length = 1){
+            recommend = await pool.query(findUserAllToStyle1, [userId, style[0][0].style_name]);
+        }else if(style[0].length = 2){
+            recommend = await pool.query(findUserAllToStyle2, [userId, style[0][1].style_name, style[0].style_name]);
         }else{
             throw new BaseError(status.MYPROFILE_PREFER_STYLE_LENGHT_ERROR);
         }

--- a/src/domains/recommend/recommend.dao.js
+++ b/src/domains/recommend/recommend.dao.js
@@ -1,0 +1,40 @@
+import { pool } from "../../config/db.config.js";
+import { BaseError } from "../../config/error.js";
+import { status } from "../../config/response.status.js";
+import { getUser, getFitToUserId, getStyleToUserId, findUserToStyle1, findUserToStyle2 } from "./recommend.sql.js";
+
+export const getStyleDAO = async (userId) => {
+    try {
+        const conn = await pool.getConnection();
+        const result = [];
+        const style = await pool.query(getStyleToUserId, userId);
+        let recommend;
+
+        if(style[0].length = 1){
+            recommend = await pool.query(findUserToStyle1, [userId, style[0][0].style_name]);
+        }else if(style[0].length = 2){
+            recommend = await pool.query(findUserToStyle2, [userId, style[0][1].style_name, style[0].style_name]);
+        }else{
+            throw new BaseError(status.MYPROFILE_PREFER_STYLE_LENGHT_ERROR);
+        }
+
+        if(recommend[0].length == 0){
+            conn.release();
+            return -1;
+        }else{
+            for (let i = 0; i < recommend[0].length; i++) {
+                const user = await pool.query(getUser, recommend[0][i].uuid);
+                const fit = await pool.query(getFitToUserId, recommend[0][i].uuid);
+                const style = await pool.query(getStyleToUserId, recommend[0][i].uuid);
+                result.push({user, fit, style});
+            }
+        }
+        conn.release();
+        return result;
+    } catch (err) {
+        if (err.data.code === status.MYPROFILE_PREFER_STYLE_LENGHT_ERROR.code) {
+            throw err;
+        }
+        throw new BaseError(status.PARAMETER_IS_WRONG);
+    }
+}

--- a/src/domains/recommend/recommend.dto.js
+++ b/src/domains/recommend/recommend.dto.js
@@ -1,0 +1,19 @@
+export const getStyleDTO = (data) => {
+    const user = [];
+    if(data == -1){
+        user.push("해당 유저는 등록되어 있지 않아요.");
+    }else{
+        for (let i = 0; i < data.length; i++) {
+            user.push({
+                "user_id": data[i].user[0][0].uuid,
+                "nickname": data[i].user[0][0].nickname,
+                "user_image": data[i].user[0][0].img_url,
+                "height": data[i].user[0][0].height,
+                "weight": data[i].user[0][0].weight,
+                "prefer_fit": data[i].fit[0].map(fitItem => fitItem.pf_name),
+                "prefer_style": data[i].style[0].map(styleItem => styleItem.style_name)
+            })
+        }
+    }
+    return {"userData": user};
+}

--- a/src/domains/recommend/recommend.provider.js
+++ b/src/domains/recommend/recommend.provider.js
@@ -1,0 +1,6 @@
+import { getStyleDTO } from "./recommend.dto.js"
+import { getStyleDAO } from "./recommend.dao.js";
+
+export const getStyle = async (userId) => {
+    return getStyleDTO(await getStyleDAO(userId));
+}

--- a/src/domains/recommend/recommend.provider.js
+++ b/src/domains/recommend/recommend.provider.js
@@ -1,6 +1,10 @@
 import { getStyleDTO } from "./recommend.dto.js"
-import { getStyleDAO } from "./recommend.dao.js";
+import { getStyleDAO, getStyleAllDAO } from "./recommend.dao.js";
 
 export const getStyle = async (userId) => {
     return getStyleDTO(await getStyleDAO(userId));
+}
+
+export const getStyleAll = async (userId) => {
+    return getStyleDTO(await getStyleAllDAO(userId));
 }

--- a/src/domains/recommend/recommend.sql.js
+++ b/src/domains/recommend/recommend.sql.js
@@ -31,3 +31,17 @@ export const findUserToFit =
 "SELECT uf.uuid, uf.style_name "
 + "FROM user_fit uf "
 + "WHERE uf.pf_name = ? ;"
+
+export const findUserAllToStyle1 =
+"SELECT DISTINCT uuid "
++ "FROM user_style "
++ "WHERE NOT uuid = ? "
++ "AND style_name = ? "
++ "ORDER BY uuid LIMIT 24;"
+
+export const findUserAllToStyle2 =
+"SELECT DISTINCT uuid "
++ "FROM user_style "
++ "WHERE NOT uuid = ? "
++ "AND (style_name = ? OR style_name = ?) "
++ "ORDER BY uuid LIMIT 24;"

--- a/src/domains/recommend/recommend.sql.js
+++ b/src/domains/recommend/recommend.sql.js
@@ -1,0 +1,33 @@
+export const getUser = 
+"SELECT m.uuid, m.nickname, m.img_url, b.height, b.weight "
++ "FROM body_info b JOIN member m on b.uuid = m.uuid "
++ "WHERE b.uuid = ? ;"
+
+export const findUserToStyle1 =
+"SELECT DISTINCT uuid "
++ "FROM user_style "
++ "WHERE NOT uuid = ? "
++ "AND style_name = ? "
++ "ORDER BY uuid LIMIT 8;"
+
+export const findUserToStyle2 =
+"SELECT DISTINCT uuid "
++ "FROM user_style "
++ "WHERE NOT uuid = ? "
++ "AND (style_name = ? OR style_name = ?) "
++ "ORDER BY uuid LIMIT 8;"
+
+export const getFitToUserId =
+"SELECT uf.uuid, uf.pf_name "
++ "FROM user_fit uf "
++ "WHERE uf.uuid = ? ;"
+
+export const getStyleToUserId =
+"SELECT us.uuid, us.style_name "
++ "FROM user_style us "
++ "WHERE us.uuid = ? ;"
+
+export const findUserToFit =
+"SELECT uf.uuid, uf.style_name "
++ "FROM user_fit uf "
++ "WHERE uf.pf_name = ? ;"

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import compareSizeRoutes from './routes/comparesize.routes.js';
 import manualResultsRoutes from './routes/manualresults.routes.js';
 import { profileRouter } from './routes/profile.js';
 import { logoutRouter } from './routes/logout.js';
+import { recommendRouter } from './routes/recommend.js';
 
 dotenv.config();
 
@@ -62,6 +63,7 @@ app.use('/temp-token', tempRouter);
 app.use('/FITple/comparesizes', compareSizeRoutes);
 app.use('/FITple/manualresults', manualResultsRoutes);
 app.use('/FITple/profile', profileRouter);
+app.use('/FITple/recommend', recommendRouter);
 
 // error handling
 app.use((req, res, next) => {

--- a/src/routes/recommend.js
+++ b/src/routes/recommend.js
@@ -1,0 +1,9 @@
+import express from "express";
+import asyncHandler from 'express-async-handler';
+import { LoginCheck } from "../middlewares/logincheck.js";
+import { style } from "../domains/recommend/recommend.controller.js";
+
+export const recommendRouter = express.Router({mergeParams: true});
+
+//스타일 추천
+recommendRouter.get('/style', LoginCheck, asyncHandler(style));

--- a/src/routes/recommend.js
+++ b/src/routes/recommend.js
@@ -1,9 +1,12 @@
 import express from "express";
 import asyncHandler from 'express-async-handler';
 import { LoginCheck } from "../middlewares/logincheck.js";
-import { style } from "../domains/recommend/recommend.controller.js";
+import { style, styleAll } from "../domains/recommend/recommend.controller.js";
 
 export const recommendRouter = express.Router({mergeParams: true});
 
 //스타일 추천
 recommendRouter.get('/style', LoginCheck, asyncHandler(style));
+
+//스타일 추천-모두 보기
+recommendRouter.get('/style/all', LoginCheck, asyncHandler(styleAll));

--- a/src/swagger/recommend.swagger.yaml
+++ b/src/swagger/recommend.swagger.yaml
@@ -1,0 +1,182 @@
+paths:
+  /FITple/recommend/style:
+    get:
+      tags:
+        - Recommend
+      summary: 비슷한 스타일의 유저 추천
+      operationId: getRecommendStyle
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 비슷한 스타일의 유저 조회 성공
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 200
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 200
+              message:
+                type: string
+                example: "success!"
+              data:
+                type: array
+                example: {
+                  "userData": [
+                    {
+                      "user_id": 32,
+                      "nickname": "선도하는요리사",
+                      "user_image": "https://fitple-dev-bucket.s3.ap-northeast-2.amazonaws.com/image/1724175918950-fitple_logo.png",
+                      "height": 165,
+                      "weight": 56,
+                      "prefer_fit": [
+                        "오버",
+                        "슬림"
+                      ],
+                      "prefer_style": [
+                        "모던시크",
+                        "유니크"
+                      ]
+                    },
+                    {
+                      "user_id": 23,
+                      "nickname": "지속가능한펭귄",
+                      "user_image": "https://fitple-dev-bucket.s3.ap-northeast-2.amazonaws.com/image/1724175918950-fitple_logo.png",
+                      "height": 166,
+                      "weight": 59,
+                      "prefer_fit": [
+                        "레귤러",
+                        "슬림"
+                      ],
+                      "prefer_style": [
+                        "러블리",
+                        "아메카지"
+                      ]
+                    }
+                  ]
+                }
+                
+        '400':
+          description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+              isSuccess:
+                type: boolean
+              code:
+                type: integer
+              message:
+                type: string
+
+        '500':
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+              isSuccess:
+                type: boolean
+              code:
+                type: integer
+              message:
+                type: string
+
+  /FITple/recommend/style/all:
+    get:
+      tags:
+        - Recommend
+      summary: 비슷한 스타일의 유저 모두 추천
+      operationId: getRecommendStyleAll
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 비슷한 스타일의 유저 모두 조회 성공
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+                example: 200
+              isSuccess:
+                type: boolean
+                example: true
+              code:
+                type: integer
+                example: 200
+              message:
+                type: string
+                example: "success!"
+              data:
+                type: array
+                example: {
+                  "userData": [
+                    {
+                      "user_id": 32,
+                      "nickname": "선도하는요리사",
+                      "user_image": "https://fitple-dev-bucket.s3.ap-northeast-2.amazonaws.com/image/1724175918950-fitple_logo.png",
+                      "height": 165,
+                      "weight": 56,
+                      "prefer_fit": [
+                        "오버",
+                        "슬림"
+                      ],
+                      "prefer_style": [
+                        "모던시크",
+                        "유니크"
+                      ]
+                    },
+                    {
+                      "user_id": 23,
+                      "nickname": "지속가능한펭귄",
+                      "user_image": "https://fitple-dev-bucket.s3.ap-northeast-2.amazonaws.com/image/1724175918950-fitple_logo.png",
+                      "height": 166,
+                      "weight": 59,
+                      "prefer_fit": [
+                        "레귤러",
+                        "슬림"
+                      ],
+                      "prefer_style": [
+                        "러블리",
+                        "아메카지"
+                      ]
+                    }
+                  ]
+                }
+                
+        '400':
+          description: 잘못된 요청
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+              isSuccess:
+                type: boolean
+              code:
+                type: integer
+              message:
+                type: string
+
+        '500':
+          description: 서버 에러
+          schema:
+            type: object
+            properties:
+              status:
+                type: integer
+              isSuccess:
+                type: boolean
+              code:
+                type: integer
+              message:
+                type: string


### PR DESCRIPTION
### 🎋 작업중인 브랜치

- feat/#124_backend_recommend-style

### ⚡️ 작업동기

- 추천 탭의 비슷한 스타일의 유저 추천하는 로직 구현

### 🔑 주요 변경사항

- 로그인한 유저의 선호 스타일과 동일한 스타일을 선택한 유저 추천하는 API 개발
- 스타일 추천-모두보기 버튼 API 개발
- 유저의 선호 스타일이 1개일 경우: 해당 스타일을 포함해서 선택한 유저 추천
- 유저의 선호 스타일이 2개일 경우: 스타일1 또는 스타일2를 포함해서 선택한 유저 추천
- uuid 순서로 조회가 됩니다. 선호 스타일이 모두 일치하는 유저를 먼저 조회하는 기능은 차후에 개발해보겠습니다!

### 💡 관련 이슈

- #124 
- 모두보기 시 추천 유저는 최대 24명까지만 출력하도록 설계했습니다

![localhost_3000_api-docs_ (6)](https://github.com/user-attachments/assets/956fbaea-804d-4e79-a7d8-4c2848e55808)
![localhost_3000_api-docs_ (7)](https://github.com/user-attachments/assets/06d6e52d-9da4-4504-86e3-6e7a9de0e863)
![스크린샷 2024-09-20 134250](https://github.com/user-attachments/assets/4a369f65-9091-4bca-974d-72b9c277910a)
![스크린샷 2024-09-20 134308](https://github.com/user-attachments/assets/82e5ba91-8840-4509-97ed-da9364a9ef28)
