### PR TITLE
wish 삭제 로직 구현

### DIFF
--- a/src/domains/closet/closet.dao.js
+++ b/src/domains/closet/closet.dao.js
@@ -4,7 +4,7 @@ import { status } from "../../config/response.status.js";
 import { myClosetItem, myClosetCategoryItem, myClosetSearchItem, myClosetSearchCategoryItem,
     getClothByClothId, getUserByClothId, getRealSizeByClothId,
     brandToBrandName, insertBrand, getBrand, insertCloth, insertRealSize, getCloth,
-    updateCloth, updateRealSize, myClothSizeDel, myClothDel } from "./closet.sql.js";
+    updateCloth, updateRealSize, myClothSizeDel, myClothWishDel, myClothDel } from "./closet.sql.js";
 
 // cloth 반환
     export const getMyClosetPreview = async (userId, name, category) => {
@@ -154,6 +154,7 @@ export const clothDel = async (userId, clothId) => {
     try {
         const conn = await pool.getConnection();
         await pool.query(myClothSizeDel, parseInt(clothId));
+        await pool.query(myClothWishDel, parseInt(clothId));
         await pool.query(myClothDel, [userId, parseInt(clothId)]);
         const cloth = await pool.query(getCloth, parseInt(clothId));
 

--- a/src/domains/closet/closet.sql.js
+++ b/src/domains/closet/closet.sql.js
@@ -70,5 +70,8 @@ export const updateRealSize =
 export const myClothSizeDel =
 "DELETE FROM real_size WHERE cloth_id = ? ;"
 
+export const myClothWishDel =
+"DELETE FROM wish WHERE cloth_id = ? ;"
+
 export const myClothDel =
 "DELETE FROM cloth WHERE uuid = ? AND id = ? ;"


### PR DESCRIPTION
### 🎋 작업중인 브랜치

- feat/#130_backend_wish-cloth-del

### ⚡️ 작업동기

- 옷장 아이템 삭제 시 wish 테이블에 데이터 존재하면 에러 발생

### 🔑 주요 변경사항

- 아이템 삭제 요청 시 wish 먼저 삭제

### 💡 관련 이슈

- #130 

string1 계정으로 로그인,  swaggerTest의 cloth_id=32 아이템을 wish에 추가
![localhost_3000_api-docs_ (9)](https://github.com/user-attachments/assets/d406d7ef-6426-41f3-ac2d-eb266aadac0a)

swaggerTest 계정으로 로그인, cloth_id=32 아이템 삭제 성공
![localhost_3000_api-docs_ (10)](https://github.com/user-attachments/assets/fb37b4da-3fbc-4fdc-a570-24b42ad227f7)
